### PR TITLE
FEATURE: Add `@path` meta-property to render child-nodes into fusion pathes

### DIFF
--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -110,12 +110,15 @@ class AfxService
 
         if ($payload['children'] && count($payload['children']) > 0) {
             foreach ($payload['children'] as $child) {
-                if ($child['type'] === 'node'
-                    && array_key_exists('@path', $child['payload']['props'])
-                    && $child['payload']['props']['@path']['type'] === 'string'
-                ) {
-                    $pathChildren[$child['payload']['props']['@path']['payload']] = $child;
-                    continue;
+                if ($child['type'] === 'node' && array_key_exists('@path', $child['payload']['props'])) {
+                    if ($child['payload']['props']['@path']['type'] === 'string') {
+                        $pathChildren[$child['payload']['props']['@path']['payload']] = $child;
+                        continue;
+                    } else {
+                        throw new AfxException(
+                            sprintf('@path only supports string payloads %s found', $child['payload']['props']['@path']['type'])
+                        );
+                    }
                 }
                 $contentChildren[] = $child;
             }
@@ -227,13 +230,13 @@ class AfxService
                 // detect key
                 $fusionName = 'item_' . $index;
                 if ($keyProperty = Arrays::getValueByPath($astNode, 'payload.props.@key')) {
-                    if ($keyProperty['type'] == 'string') {
+                    if ($keyProperty['type'] === 'string') {
                         $fusionName = $keyProperty['payload'];
                     } else {
                         throw new AfxException(
                             sprintf(
                                 '@key only supports string payloads %s was given',
-                                $astNode['props']['@key']['type']
+                                $keyProperty['type']
                             )
                         );
                     }

--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -105,6 +105,22 @@ class AfxService
     {
         $tagName = $payload['identifier'];
 
+        $pathChildren = [];
+        $contentChildren = [];
+
+        if ($payload['children'] && count($payload['children']) > 0) {
+            foreach ($payload['children'] as $child) {
+                if ($child['type'] === 'node'
+                    && array_key_exists('@path', $child['payload']['props'])
+                    && $child['payload']['props']['@path']['type'] === 'string'
+                ) {
+                    $pathChildren[$child['payload']['props']['@path']['payload']] = $child;
+                    continue;
+                }
+                $contentChildren[] = $child;
+            }
+        }
+
         // Tag
         if (strpos($tagName, ':') !== false) {
             // Named fusion-object
@@ -126,7 +142,7 @@ class AfxService
         // Attributes
         if ($payload['props'] && count($payload['props']) > 0) {
             foreach ($payload['props'] as $propName => $prop) {
-                if ($propName == '@key' || $propName == '@children') {
+                if ($propName === '@key' || $propName === '@children' || $propName === '@path') {
                     continue;
                 } else {
                     if ($propName{0} === '@') {
@@ -134,7 +150,7 @@ class AfxService
                     } else {
                         $fusionName = $attributePrefix . $propName;
                     }
-                    $propFusion =  self::astToFusion($prop, $indentation . self::INDENTATION);
+                    $propFusion = self::astToFusion($prop, $indentation . self::INDENTATION);
                     if ($propFusion !== null) {
                         $fusion .= $indentation . self::INDENTATION . $fusionName . ' = ' . $propFusion . PHP_EOL;
                     }
@@ -142,11 +158,18 @@ class AfxService
             }
         }
 
-        // Children
-        if ($payload['children'] && count($payload['children']) > 0) {
+        // Path Children
+        if ($pathChildren !== []) {
+            foreach ($pathChildren as $path => $child) {
+                $fusion .= $indentation . self::INDENTATION . $path . ' = ' . self::astToFusion($child, $indentation . self::INDENTATION) . PHP_EOL;
+            }
+        }
+
+        // Content Children
+        if ($contentChildren !== []) {
             $childrenProp = Arrays::getValueByPath($payload, 'props.@children');
             if ($childrenProp) {
-                if ($childrenProp['type'] == 'string') {
+                if ($childrenProp['type'] === 'string') {
                     $childrenPropertyName = $childrenProp['payload'];
                 } else {
                     throw new AfxException(
@@ -156,7 +179,8 @@ class AfxService
             } else {
                 $childrenPropertyName = 'content';
             }
-            $childFusion = self::astNodeListToFusion($payload['children'], $indentation . self::INDENTATION);
+
+            $childFusion = self::astNodeListToFusion($contentChildren, $indentation . self::INDENTATION);
             if ($childFusion) {
                 $fusion .= $indentation . self::INDENTATION . $childrenPropertyName . ' = ' . $childFusion . PHP_EOL;
             }
@@ -178,7 +202,7 @@ class AfxService
 
         // ignore blank text if it is connected to a newline
         $payload = array_map(function ($astNode) {
-            if ($astNode['type'] == 'text') {
+            if ($astNode['type'] === 'text') {
                 $astNode['payload'] = preg_replace('/[\\s]*\\n[\\s]*/u', '', $astNode['payload']);
             }
             return $astNode;
@@ -186,16 +210,16 @@ class AfxService
 
         // filter empty text nodes
         $payload = array_filter($payload, function ($astNode) {
-            if ($astNode['type'] == 'text' && $astNode['payload'] == '') {
+            if ($astNode['type'] === 'text' && $astNode['payload'] == '') {
                 return false;
             } else {
                 return true;
             }
         });
 
-        if (count($payload) == 0) {
+        if (count($payload) === 0) {
             return '\'\'';
-        } elseif (count($payload) == 1) {
+        } elseif (count($payload) === 1) {
             return self::astToFusion(array_shift($payload), $indentation);
         } else {
             $fusion = 'Neos.Fusion:Array {' . PHP_EOL;

--- a/README.md
+++ b/README.md
@@ -218,13 +218,15 @@ Vendor.Site:Prototype {
 In general all meta-attributes start with an @-sign. 
 
 The `@path`-attribute can be used to render a child node directly into the given path below the parent Fusion:Object
-instead of beeing included into the `content` property. 
+instead of beeing included into the `content` property.
 
 The `@children`-attribute defined the property that is used to render the content/children of the current tag into. 
 The default property name for the children is `content`.
 
 The `@key`-attribute can be used to define the property name of an item among its siblings if an array is rendered. 
 If no `@key` is defined `index_x` is used starting at `x=1. 
+
+Attention: `@path`, `@children` and `@key` only support string-values and no expressions.
 
 All other meta attributes are directly added to the generated prototype and can be used for @if or @process statements. 
 

--- a/README.md
+++ b/README.md
@@ -189,9 +189,36 @@ Vendor.Site:Prototype {
 }
 ```
 
+The `@path`-property of tag-children can be used to render a specific afx-child into the given fusion path
+instead of beeing included into the `content`. This allows to render AFX children into different props and
+to assign Fusion-prototypes to props.
+
+```
+<Vendor.Site:Prototype>
+    <h2 @path="title">{props.title}</h1> 
+    <p @path="description">{props.description}</p>
+</Vendor.Site:Prototype>
+``` 
+Is transpiled as:
+```
+Vendor.Site:Prototype {
+    title = Neos.Fusion:Tag {
+        tagName = 'h2'
+        content  = ${props.title}
+    }
+    description = Neos.Fusion:Tag {
+        tagName = 'p'
+        content  = ${props.description}
+    }
+}
+```
+
 ### Meta-Attributes
 
 In general all meta-attributes start with an @-sign. 
+
+The `@path`-attribute can be used to render a child node directly into the given path below the parent Fusion:Object
+instead of beeing included into the `content` property. 
 
 The `@children`-attribute defined the property that is used to render the content/children of the current tag into. 
 The default property name for the children is `content`.

--- a/Tests/Functional/AfxServiceTest.php
+++ b/Tests/Functional/AfxServiceTest.php
@@ -448,6 +448,93 @@ EOF;
     /**
      * @test
      */
+    public function childrenWithPathesAreRendered()
+    {
+        $afxCode = '<Vendor.Site:Prototype><strong @path="namedProp">foo</strong></Vendor.Site:Prototype>';
+        $expectedFusion = <<<'EOF'
+Vendor.Site:Prototype {
+    namedProp = Neos.Fusion:Tag {
+        tagName = 'strong'
+        content = 'foo'
+    }
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function multipleChildrenWithPathesAreRendered()
+    {
+        $afxCode = '<Vendor.Site:Prototype><strong @path="propOne">foo</strong><Vendor.Site:Prototype @path="propTwo">bar</Vendor.Site:Prototype></Vendor.Site:Prototype>';
+        $expectedFusion = <<<'EOF'
+Vendor.Site:Prototype {
+    propOne = Neos.Fusion:Tag {
+        tagName = 'strong'
+        content = 'foo'
+    }
+    propTwo = Vendor.Site:Prototype {
+        content = 'bar'
+    }
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function childrenWithPathesAreCompatibleWithContentChildren()
+    {
+        $afxCode = '<Vendor.Site:Prototype><strong @path="propOne">foo</strong><Vendor.Site:Prototype @path="propTwo">bar</Vendor.Site:Prototype><div>a tag</div><div>another tag</div></Vendor.Site:Prototype>';
+        $expectedFusion = <<<'EOF'
+Vendor.Site:Prototype {
+    propOne = Neos.Fusion:Tag {
+        tagName = 'strong'
+        content = 'foo'
+    }
+    propTwo = Vendor.Site:Prototype {
+        content = 'bar'
+    }
+    content = Neos.Fusion:Array {
+        item_1 = Neos.Fusion:Tag {
+            tagName = 'div'
+            content = 'a tag'
+        }
+        item_2 = Neos.Fusion:Tag {
+            tagName = 'div'
+            content = 'another tag'
+        }
+    }
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function childrenWithDeepPathesAreSupported()
+    {
+        $afxCode = '<Vendor.Site:Prototype><strong @path="a.fusion.path">foo</strong><Vendor.Site:Prototype @path="another.fusion.path">bar</Vendor.Site:Prototype></Vendor.Site:Prototype>';
+        $expectedFusion = <<<'EOF'
+Vendor.Site:Prototype {
+    a.fusion.path = Neos.Fusion:Tag {
+        tagName = 'strong'
+        content = 'foo'
+    }
+    another.fusion.path = Vendor.Site:Prototype {
+        content = 'bar'
+    }
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
     public function spacesNewLinesAndSpacesAroundAreIgnored()
     {
         $afxCode = '<h1>

--- a/Tests/Functional/AfxServiceTest.php
+++ b/Tests/Functional/AfxServiceTest.php
@@ -629,4 +629,36 @@ EOF;
         $afxCode = '<h1 foo={"123" />';
         AfxService::convertAfxToFusion($afxCode);
     }
+
+    /**
+     * @test
+     * @expectedException \Neos\Fusion\Afx\Exception\AfxException
+     */
+    public function childPathAnnotationWithExpressionRaisesException()
+    {
+        $afxCode = '<div><span @path={expression} /></div>';
+        AfxService::convertAfxToFusion($afxCode);
+    }
+
+    /**
+     * @test
+     * @expectedException \Neos\Fusion\Afx\Exception\AfxException
+     */
+    public function keyAnnotationWithExpressionRaisesException()
+    {
+        $afxCode = '<div><span @key={expression} /><span/></div>';
+        AfxService::convertAfxToFusion($afxCode);
+    }
+
+    /**
+     * @test
+     * @expectedException \Neos\Fusion\Afx\Exception\AfxException
+     */
+    public function childrenAnnotationWithExpressionRaisesException()
+    {
+        $afxCode = '<div @children={expression} ><span/></div>';
+        AfxService::convertAfxToFusion($afxCode);
+    }
+
+
 }


### PR DESCRIPTION
The `@path`-property of tag-children can be used to render a specific afx-child into the given fusion path instead of beeing included into the default `content`-property.

```
<Vendor.Site:ExampleContainer>
    <h2 @path="header">{props.title}</h1>
    <p @path="body">{props.description}</p>
</Vendor.Site:Prototype>
```
Is transpiled as:
```
Vendor.Site:ExampleContainer {
    header = Neos.Fusion:Tag {
        tagName = 'h2'
        content  = ${props.title}
    }
    body = Neos.Fusion:Tag {
        tagName = 'p'
        content  = ${props.description}
    }
}
```