### PR TITLE
BUGFIX: Support slashes in texts property

### DIFF
--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -93,7 +93,7 @@ class AfxService
      */
     protected static function astTextToFusion($payload, $indentation = '')
     {
-        return '\'' . str_replace('\'', '\\\'', $payload) . '\'';
+        return '\'' . addslashes($payload) . '\'';
     }
 
     /**

--- a/Tests/Functional/AfxServiceTest.php
+++ b/Tests/Functional/AfxServiceTest.php
@@ -515,6 +515,40 @@ EOF;
 
     /**
      * @test
+     */
+    public function slashesInTextNodesArePreserved()
+    {
+        $afxCode = '<h1>\o/</h1>';
+
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'h1'
+    content = '\\o/'
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function textsAreEscaped()
+    {
+        $afxCode = <<<'EOF'
+<h1>foo'bar\baz"bam</h1>
+EOF;
+
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'h1'
+    content = 'foo\'bar\\baz\"bam'
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+    
+    /**
+     * @test
      * @expectedException \PackageFactory\Afx\Exception
      */
     public function unclosedTagsRaisesException()


### PR DESCRIPTION
Previously only single quotes were escaped in afx text and string nodes. This changes
introduces a more generic escaping via addslashes that includes slashes, single- and double-quotes.
That way the rendered result of afx should match the expectation better.

resolves: #2