### PR TITLE
FEATURE: Support ES6 spreads in AFX

### DIFF
--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -156,7 +156,7 @@ class AfxService
             foreach ($payload['children'] as $child) {
                 if ($child['type'] === 'node') {
                     $path = null;
-                    foreach($child['payload']['attributes'] as $attribute) {
+                    foreach ($child['payload']['attributes'] as $attribute) {
                         if ($attribute['type'] === 'prop' && $attribute['payload']['identifier'] === '@path') {
                             $pathAttribute = $attribute['payload'];
                             if ($pathAttribute['type'] === 'string') {

--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -145,8 +145,21 @@ class AfxService
 
         // Attributes
         if ($payload['attributes'] && count($payload['attributes']) > 0) {
+            $spreadIndex = 1;
             foreach ($payload['attributes'] as $attribute) {
-                if ($attribute['type'] === 'prop') {
+                if ($attribute['type'] === 'spread') {
+                    if ($attribute['payload']['type'] === 'expression') {
+                        $spreadFusion = self::astToFusion($attribute['payload'], $indentation . self::INDENTATION);
+                        if ($spreadFusion !== null) {
+                            $fusion .= $indentation . self::INDENTATION . $attributePrefix . '@spread.spread_' . $spreadIndex . ' = ' . $spreadFusion . PHP_EOL;
+                            $spreadIndex++;
+                        }
+                    } else {
+                        throw new AfxException(
+                            sprintf('Spreads only support expression payloads %s found', $attribute['payload']['type'])
+                        );
+                    }
+                } elseif ($attribute['type'] === 'prop') {
                     $prop = $attribute['payload'];
                     $propName = $prop['identifier'];
                     if ($propName === '@key') {
@@ -166,7 +179,7 @@ class AfxService
                         } else {
                             $fusionName = $attributePrefix . $propName;
                         }
-                        $propFusion =self::astToFusion($prop, $indentation . self::INDENTATION);
+                        $propFusion = self::astToFusion($prop, $indentation . self::INDENTATION);
                         if ($propFusion !== null) {
                             $fusion .= $indentation . self::INDENTATION . $fusionName . ' = ' . $propFusion . PHP_EOL;
                         }

--- a/README.md
+++ b/README.md
@@ -126,30 +126,31 @@ To apply multiple properties to a fusion prototype with a single expression
 afx supports the spread syntax from ES6:
 
 ```
-<Vendor.Site:Prototype {...data} />
+<Vendor.Site:Component {...expression} />
 ```
 Is transpiled as:
 ```
-Vendor.Site:Prototype {
-    @apply.spread_1 = ${data}
+Vendor.Site:Component {
+    @apply.spread_1 = ${expression}
 }
 ```
 
 Spreads can be combined with props and the order of the definition is
-of props and spreads is preserved. So spreads override previously defined
-props but are overwritten again by later properties.
+of props and spreads is preserved, spreads will override previously
+defined props but are overwritten again by later props.
 
-The combination of spreads and properties works by only rendering
-the properties before the first spread as fusion properties. The spreads
-and the following props are transpiled to fusion `@apply` statements
-to preserve the order of the assignment.
+The order preserving combination of spreads and properties works by
+only rendering the properties before the first spread as classic
+fusion properties. Spreads and the following props are transpiled to
+fusion `@apply` statements and are thus able to override all props but
+and are evaluated in the order of definition.
 
 ```
-<Vendor.Site:Prototype title="example" {...data} description="description" {...moreData} />
+<Vendor.Site:Component title="example" {...data} description="description" {...moreData} />
 ```
 Is transpiled as:
 ```
-Vendor.Site:Prototype {
+Vendor.Site:Component {
     title = 'example'
     @apply.spread_1 = ${data}
     @apply.spread_2 = Neos.Fusion:RawArray {
@@ -160,6 +161,7 @@ Vendor.Site:Prototype {
 }
 ```
 
+**This feature is based on the `@apply`-syntax of fusion and thus will only work in Neos > 4.2.**
 
 ### Tag-Children
 
@@ -292,7 +294,7 @@ Neos.Fusion:Tag {
 	tagName = 'h1'
 	contents = Neos.Fusion:Array {
 		item_1 = ${'eelExpression 1'}
-		item_2 = ${'eelExpression 2'}   
+		item_2 = ${'eelExpression 2'}
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -120,6 +120,47 @@ Vendor.Site:Prototype {
 }
 ```
 
+### Spread Syntax
+
+To apply multiple properties to a fusion prototype with a single expression
+afx supports the spread syntax from ES6:
+
+```
+<Vendor.Site:Prototype {...data} />
+```
+Is transpiled as:
+```
+Vendor.Site:Prototype {
+    @apply.spread_1 = ${data}
+}
+```
+
+Spreads can be combined with props and the order of the definition is
+of props and spreads is preserved. So spreads override previously defined
+props but are overwritten again by later properties.
+
+The combination of spreads and properties works by only rendering
+the properties before the first spread as fusion properties. The spreads
+and the following props are transpiled to fusion `@apply` statements
+to preserve the order of the assignment.
+
+```
+<Vendor.Site:Prototype title="example" {...data} description="description" {...moreData} />
+```
+Is transpiled as:
+```
+Vendor.Site:Prototype {
+    title = 'example'
+    @apply.spread_1 = ${data}
+    @apply.spread_2 = Neos.Fusion:RawArray {
+        description = 'description'
+    }
+    @apply.spread_3 = ${moreData}
+
+}
+```
+
+
 ### Tag-Children
 
 The handling of child-nodes below an afx-node is differs based on the number of childNodes that are found.
@@ -291,8 +332,10 @@ prototype(Vendor.Site:IterationExample) < prototype(Neos.Fusion:Component) {
     
     renderer = afx`
         <ul @if.has={props.items ? true : false}>
-        <Neos.Fusion:Collection collection={props.items} itemName="item" @children="itemRenderer">
-            <li><a href={item.href}>{item.title}</a></li>
+        <Neos.Fusion:Collection collection={props.items} itemName="item">
+            <li @path='itemRenderer'>
+                <Vendor.Site:LinkExample {...item} />
+            </li>
         </Neos.Fusion:Collection>
         </ul>
     `
@@ -312,7 +355,7 @@ prototype(PackageFactory.AtomicFusion.AFX:SliderExample) < prototype(Packagefact
      <div class="slider">
         <Neos.Fusion:Collection collection={props.images} itemName="image" iterationName="iteration" @children="itemRenderer">
             <Neos.Fusion:Augmenter class="slider__slide" data-index={iteration.index}>
-                <Vendor.Site:ImageExample image={image} /> 
+                <Vendor.Site:ImageExample {...image} />
             </Neos.Fusion:Augmenter>
         </Neos.Fusion:Collection>  
      </div>

--- a/Tests/Functional/AfxServiceTest.php
+++ b/Tests/Functional/AfxServiceTest.php
@@ -602,6 +602,39 @@ EOF;
 
     /**
      * @test
+     */
+    public function spreadsAreEvaluetedForFusionObjectTags()
+    {
+        $afxCode = '<Vendor.Site:Prototype {...contextValue} />';
+
+        $expectedFusion = <<<'EOF'
+Vendor.Site:Prototype {
+    @spread.spread_1 = ${contextValue}
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function spreadsAreEvaluetedForHtmlTags()
+    {
+        $afxCode = '<h1 {...contextValue} />';
+
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'h1'
+    selfClosingTag = true
+    attributes.@spread.spread_1 = ${contextValue}
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+
+    /**
+     * @test
      * @expectedException \PackageFactory\Afx\Exception
      */
     public function unclosedTagsRaisesException()

--- a/Tests/Functional/AfxServiceTest.php
+++ b/Tests/Functional/AfxServiceTest.php
@@ -603,13 +603,13 @@ EOF;
     /**
      * @test
      */
-    public function spreadsAreEvaluetedForFusionObjectTags()
+    public function spreadsAreEvaluatedForFusionObjectTags()
     {
         $afxCode = '<Vendor.Site:Prototype {...spreadExpression} />';
 
         $expectedFusion = <<<'EOF'
 Vendor.Site:Prototype {
-    @spread.spread_1 = ${spreadExpression}
+    @apply.spread_1 = ${spreadExpression}
 }
 EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
@@ -626,8 +626,8 @@ EOF;
 Vendor.Site:Prototype {
     stringBefore = 'string'
     expressionBefore = ${expression}
-    @spread.spread_1 = ${spreadExpression}
-    @spread.spread_2 = Neos.Fusion:RawArray {
+    @apply.spread_1 = ${spreadExpression}
+    @apply.spread_2 = Neos.Fusion:RawArray {
         stringAfter = 'string'
         expressionAfter = ${expression}
     }
@@ -648,7 +648,7 @@ EOF;
 Neos.Fusion:Tag {
     tagName = 'h1'
     selfClosingTag = true
-    attributes.@spread.spread_1 = ${spreadExpression}
+    attributes.@apply.spread_1 = ${spreadExpression}
 }
 EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
@@ -667,8 +667,8 @@ Neos.Fusion:Tag {
     selfClosingTag = true
     attributes.stringBefore = 'string'
     attributes.expressionBefore = ${expression}
-    attributes.@spread.spread_1 = ${spreadExpression}
-    attributes.@spread.spread_2 = Neos.Fusion:RawArray {
+    attributes.@apply.spread_1 = ${spreadExpression}
+    attributes.@apply.spread_2 = Neos.Fusion:RawArray {
         stringAfter = 'string'
         expressionAfter = ${expression}
     }

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
     "packagefactory/atomicfusion-afx": "*"
   },
   "require": {
-    "neos/fusion": "^3.2.0 || ^4.0.0 || dev-master",
-    "packagefactory/afx": "dev-feature/spreads"
+    "neos/fusion": "^4.2.0 || dev-master",
+    "packagefactory/afx": "^3.0.0"
   },
   "repositories": {
     "mficzel-afx": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,13 @@
   },
   "require": {
     "neos/fusion": "^3.2.0 || ^4.0.0 || dev-master",
-    "packagefactory/afx": "~2.0.1"
+    "packagefactory/afx": "dev-feature/spreads"
+  },
+  "repositories": {
+    "mficzel-afx": {
+      "type": "vcs",
+      "url": "https://github.com/mficzel/afx.git"
+    }
   },
   "require-dev": {
     "phpunit/phpunit": "~6.0.0"


### PR DESCRIPTION
This change introduces the ES6 spread-syntax to afx. 

The code:
```
afx`<Vendor.Site:Component {...expression} />`
```
is transpiled as: 
```
Vendor.Site:Component {
  @apply.spread_1 = ${expresion}
}
```

**The order of spreads and props is important an will be preserved.** This is ensured by handling the props that are defined after spreads differently. While props that are assigned before the first spread are rendered as fusion-attributes (like afx always did) starting with the first spread the props are rendered as spread aswell to be able to override the values that may be defined by the previous spread. This is necessary since ``@apply`` is always checked first and will override fusion properties on that level entirely.

```
afx`<Vendor.Site:Component title={props.title} {...props.data} uri={props.uri} />`
```
is transpiled as:
```
Vendor.Site:Component {
  title = ${props.title} 
  @apply.spread_1 = ${props.data} 
  @apply.spread_2 = Neos.Fusion:RawArray {
    uri = ${props.uri}
  }
}
``` 

**This feature is based on the ``@apply``-syntax of fusion and thus will only work in Neos > 4.2.**