### PR TITLE
BUGFIX: Restore fusion version requirement ^4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "packagefactory/atomicfusion-afx": "*"
   },
   "require": {
-    "neos/fusion": "^4.2.0 || dev-master"
+    "neos/fusion": "^4.2 || ^5.0 || dev-master"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.1"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "packagefactory/atomicfusion-afx": "*"
   },
   "require": {
-    "neos/fusion": "*"
+    "neos/fusion": "^4.2.0 || dev-master"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.1"


### PR DESCRIPTION
The version requirement for Fusion ^4.2 is needed to prevent older versions of Neos from updating to an incompatible afx version.