### PR TITLE
FEATURE: Support html comment syntax in afx

### DIFF
--- a/Classes/Parser/Expression/Comment.php
+++ b/Classes/Parser/Expression/Comment.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Fusion\Afx\Parser\Expression;
+
+/*
+ * This file is part of the Neos.Fusion.Afx package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Fusion\Afx\Parser\AfxParserException;
+use Neos\Fusion\Afx\Parser\Lexer;
+
+/**
+ * Class Expression
+ * @package Neos\Fusion\Afx\Parser\Expression
+ */
+class Comment
+{
+    /**
+     * @param Lexer $lexer
+     * @return string
+     * @throws AfxParserException
+     */
+    public static function parse(Lexer $lexer)
+    {
+        if ($lexer->isOpeningBracket() && $lexer->peek(4) === '<!--') {
+            $lexer->consume();
+            $lexer->consume();
+            $lexer->consume();
+            $lexer->consume();
+        } else {
+            throw new AfxParserException(sprintf('Unexpected comment start'));
+        }
+        $currentComment = '';
+        while (true) {
+            if ($lexer->isMinus() && $lexer->peek(3) === '-->') {
+                $lexer->consume();
+                $lexer->consume();
+                $lexer->consume();
+                return $currentComment;
+            }
+            if ($lexer->isEnd()) {
+                throw new AfxParserException(sprintf('Comment not closed.'));
+            }
+            $currentComment .= $lexer->consume();
+        }
+    }
+}

--- a/Classes/Parser/Expression/Node.php
+++ b/Classes/Parser/Expression/Node.php
@@ -43,6 +43,7 @@ class Node
                 while ($lexer->isWhitespace()) {
                     $lexer->consume();
                 }
+
                 while (!$lexer->isForwardSlash() && !$lexer->isClosingBracket()) {
                     if ($lexer->isOpeningBrace()) {
                         $attributes[] = [

--- a/Classes/Parser/Expression/NodeList.php
+++ b/Classes/Parser/Expression/NodeList.php
@@ -43,7 +43,8 @@ class NodeList
                 if ($lexer->isForwardSlash()) {
                     $lexer->rewind();
                     return $contents;
-                } elseif ($lexer->isExclamationMark()) {
+                }
+                if ($lexer->isExclamationMark()) {
                     $lexer->rewind();
                     $contents[] = [
                         'type' => 'comment',

--- a/Classes/Parser/Expression/NodeList.php
+++ b/Classes/Parser/Expression/NodeList.php
@@ -34,25 +34,25 @@ class NodeList
         while (!$lexer->isEnd()) {
             if ($lexer->isOpeningBracket()) {
                 $lexer->consume();
-
+                if ($currentText) {
+                    $contents[] = [
+                        'type' => 'text',
+                        'payload' => $currentText
+                    ];
+                }
                 if ($lexer->isForwardSlash()) {
                     $lexer->rewind();
-                    if ($currentText) {
-                        $contents[] = [
-                            'type' => 'text',
-                            'payload' => $currentText
-                        ];
-                    }
                     return $contents;
+                } elseif ($lexer->isExclamationMark()) {
+                    $lexer->rewind();
+                    $contents[] = [
+                        'type' => 'comment',
+                        'payload' => Comment::parse($lexer)
+                    ];
+                    $currentText = '';
+                    continue;
                 } else {
                     $lexer->rewind();
-
-                    if ($currentText) {
-                        $contents[] = [
-                            'type' => 'text',
-                            'payload' => $currentText
-                        ];
-                    }
                     $contents[] = [
                         'type' => 'node',
                         'payload' => Node::parse($lexer)

--- a/Classes/Parser/Lexer.php
+++ b/Classes/Parser/Lexer.php
@@ -224,6 +224,16 @@ class Lexer
     }
 
     /**
+     * Checks if the current character is an exclamation mark
+     *
+     * @return boolean
+     */
+    public function isExclamationMark(): bool
+    {
+        return $this->currentCharacter === '!';
+    }
+
+    /**
      * Checks if the iteration has ended
      *
      * @return boolean

--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -309,9 +309,11 @@ class AfxService
             return $astNode;
         }, $payload);
 
-        // filter empty text nodes
+        // filter empty text nodes and comments
         $payload = array_filter($payload, function ($astNode) {
             if ($astNode['type'] === 'text' && $astNode['payload'] == '') {
+                return false;
+            } elseif ($astNode['type'] === 'comment') {
                 return false;
             } else {
                 return true;

--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -313,11 +313,11 @@ class AfxService
         $payload = array_filter($payload, function ($astNode) {
             if ($astNode['type'] === 'text' && $astNode['payload'] == '') {
                 return false;
-            } elseif ($astNode['type'] === 'comment') {
-                return false;
-            } else {
-                return true;
             }
+            if ($astNode['type'] === 'comment') {
+                return false;
+            }
+            return true;
         });
 
         if (count($payload) === 0) {

--- a/Tests/Functional/AfxServiceTest.php
+++ b/Tests/Functional/AfxServiceTest.php
@@ -716,6 +716,87 @@ EOF;
     /**
      * @test
      */
+    public function commentsAreIgnored(): void
+    {
+        $afxCode = <<<'EOF'
+<!-- comment before -->
+<h1>Example<!-- comment inside -->Content</h1>
+<!-- comment after -->
+EOF;
+
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'h1'
+    content = Neos.Fusion:Array {
+        item_1 = 'Example'
+        item_2 = 'Content'
+    }
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function standaloneCommentsAreIgnored(): void
+    {
+        $afxCode = <<<'EOF'
+<!-- comment -->
+EOF;
+
+        $expectedFusion = <<<'EOF'
+''
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function standaloneCommentsChildrenAreIgnored(): void
+    {
+        $afxCode = <<<'EOF'
+<h1><!-- comment --></h1>
+EOF;
+
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'h1'
+    content = ''
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function multilineCommentsAreIgnored(): void
+    {
+        $afxCode = <<<'EOF'
+<h1>
+<!-- 
+    comment 
+    with
+    multiple 
+    lines 
+-->
+</h1>
+EOF;
+
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'h1'
+    content = ''
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
     public function slashesInStringNodesArePreserved()
     {
         $afxCode = <<<'EOF'


### PR DESCRIPTION
The html comment syntax `<!-- -->` is now supported in afx. The content inside the comment is completely ignored during the transpilation to fusion.

I decided against rendering html or fusion comments because AFX is a fusion dsl and thus comments should be transpiled to fusion comments and not html-comments. Since we currently have no way to really see the fusion comments a dsl might produce we can aswell simply ignore them.