### PR TITLE
WIP: FEATURE: Add keys to `@if` and `@process` props that have no name

### DIFF
--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -121,7 +121,9 @@ class AfxService
                 $prop = $attribute['payload'];
                 $propName = $prop['identifier'];
                 // add automatic keys to *.@if and *.@process
-                if (fnmatch('*@if', $propName) || fnmatch('*@process', $propName)) {
+                if (preg_match('/^(.+\\.@if|@if)$/u', $propName)
+                    || preg_match('/^(.+\\.@process|@process)$/u', $propName)
+                ) {
                     $index ++;
                     $propName .= '._meta_' . $index;
                 }

--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -115,10 +115,16 @@ class AfxService
     protected static function propListToFusion($payload, $attributePrefix, $indentation = '')
     {
         $fusion = '';
+        $index = 0;
         foreach ($payload as $attribute) {
             if ($attribute['type'] === 'prop') {
                 $prop = $attribute['payload'];
                 $propName = $prop['identifier'];
+                // add automatic keys to *.@if and *.@process
+                if (fnmatch('*@if', $propName) || fnmatch('*@process', $propName)) {
+                    $index ++;
+                    $propName .= '._meta_' . $index;
+                }
                 $propFusion = self::astToFusion($prop, $indentation . self::INDENTATION);
                 if ($propFusion !== null) {
                     $fusion .= $indentation . self::INDENTATION . $attributePrefix . $propName . ' = ' . $propFusion . PHP_EOL;

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ prototype(Vendor.Site:Example) < prototype(Neos.Fusion:Component) {
     renderer = afx`
        <div>
          <h1 @key="headline" class="headline">{props.title}</h1>
-         <h2 @key="subheadline" class="subheadline" @if.hasSubtitle={props.subtitle ? true : false}>{props.subtitle}</h2>
+         <h2 @key="subheadline" class="subheadline" @if={props.subtitle ? true : false}>{props.subtitle}</h2>
          <Vendor.Site:Image @key="image" uri={props.imageUri} />
        </div>
     `
@@ -59,7 +59,7 @@ prototype(Vendor.Site:Example) < prototype(Neos.Fusion:Component) {
                 tagName = 'h2'
                 content = ${props.subtitle}
                 attributes.subheadline = 'subheadline'
-                @if.hasSubtitle = ${props.subtitle ? true : false}
+                @if._meta_1 = ${props.subtitle ? true : false}
             }
             image = Vendor.Site:Image {
                 uri = ${props.imageUri}
@@ -79,7 +79,7 @@ HTML-Tags are converted to `Neos.Fusion:Tag` Objects. All attributes of the afx-
  
 The following html: 
 ```
-<h1 class="headline" @if.hasHeadline={props.headline ? true : false}>{props.headline}</h1>
+<h1 class="headline" @if={props.headline ? true : false}>{props.headline}</h1>
 ```
 Is transpiled to:
 ```
@@ -87,7 +87,7 @@ Neos.Fusion:Tag {
     tagName = 'h1'
     attributes.class = 'headline'
     content = ${props.headline}
-    @if.hasHeadline = ${props.headline ? true : false}
+    @if._meta_1 = ${props.headline ? true : false}
 }
 ``` 
 
@@ -273,6 +273,9 @@ Attention: `@path`, `@children` and `@key` only support string-values and no exp
 
 All other meta attributes are directly added to the generated prototype and can be used for @if or @process statements. 
 
+When a meta attribute ends with `@if` or `@process` without a name the afx will automatically append a unique key like 
+`_meta_xxx`.  
+
 ### Whitespace and Newlines
  
 AFX is not html and makes some simplifications to the code to optimize the generated fusion and allow a structured notation 
@@ -333,7 +336,7 @@ prototype(Vendor.Site:IterationExample) < prototype(Neos.Fusion:Component) {
     items = null
     
     renderer = afx`
-        <ul @if.has={props.items ? true : false}>
+        <ul @if={props.items ? true : false}>
         <Neos.Fusion:Collection collection={props.items} itemName="item">
             <li @path='itemRenderer'>
                 <Vendor.Site:LinkExample {...item} />

--- a/Tests/Functional/AfxServiceTest.php
+++ b/Tests/Functional/AfxServiceTest.php
@@ -290,6 +290,112 @@ EOF;
     /**
      * @test
      */
+    public function metaAttributesWithoutNamesGetAnAutomatedNamesInHtmlTags(): void
+    {
+        $afxCode = <<<'EOF'
+<div
+    @any="1"
+    @if="2"
+    @any="3" 
+    @process="4"
+    @any="5" 
+></div>
+EOF;
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'div'
+    @any = '1'
+    @if._meta_1 = '2'
+    @any = '3'
+    @process._meta_2 = '4'
+    @any = '5'
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function metaAttributesWithoutNamesGetAnAutomatedNamesInFusionTags(): void
+    {
+        $afxCode = <<<'EOF'
+<Neos.Fusion:Tag  
+    @any="1"
+    @if="2"
+    @any="3" 
+    @process="4"
+    @any="5" 
+></Neos.Fusion:Tag>
+EOF;
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    @any = '1'
+    @if._meta_1 = '2'
+    @any = '3'
+    @process._meta_2 = '4'
+    @any = '5'
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function attributesWithoutNamesGetAnAutomatedNamesInHtmlTags_(): void
+    {
+        $afxCode = <<<'EOF'
+<div
+    title.@any="1"
+    title.@if="2"
+    title.@any="3" 
+    title.@process="4"
+    title.@any="5" 
+></div>
+EOF;
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'div'
+    attributes.title.@any = '1'
+    attributes.title.@if._meta_1 = '2'
+    attributes.title.@any = '3'
+    attributes.title.@process._meta_2 = '4'
+    attributes.title.@any = '5'
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function attributesWithoutNamesGetAnAutomatedNamesInFusionTags_(): void
+    {
+        $afxCode = <<<'EOF'
+<Neos.Fusion:Tag  
+    title.@any="1"
+    title.@if="2"
+    title.@any="3" 
+    title.@process="4"
+    title.@any="5" 
+></Neos.Fusion:Tag>
+EOF;
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    title.@any = '1'
+    title.@if._meta_1 = '2'
+    title.@any = '3'
+    title.@process._meta_2 = '4'
+    title.@any = '5'
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
     public function contentOfHtmlTagsIsRenderedAsFusionContent(): void
     {
         $afxCode = '<h1>Fooo</h1>';


### PR DESCRIPTION
`@if` and `@process` need named keys in fusion which is cumbersome as this has no effect on the
evaluation.

This change extends the afx fusion service to automatically create the names keys for all props that end with `@if` or `@process`. Keys that have a name at the end and all other meta-keys are not modified.