### PR TITLE
BUGFiX: Handle zero as tag content properly

### DIFF
--- a/Classes/Parser/Expression/NodeList.php
+++ b/Classes/Parser/Expression/NodeList.php
@@ -34,7 +34,7 @@ class NodeList
         while (!$lexer->isEnd()) {
             if ($lexer->isOpeningBracket()) {
                 $lexer->consume();
-                if ($currentText) {
+                if ($currentText !== '') {
                     $contents[] = [
                         'type' => 'text',
                         'payload' => $currentText

--- a/Classes/Parser/Expression/NodeList.php
+++ b/Classes/Parser/Expression/NodeList.php
@@ -82,7 +82,7 @@ class NodeList
             $currentText .= $lexer->consume();
         }
 
-        if ($lexer->isEnd() && $currentText) {
+        if ($lexer->isEnd() && $currentText !== '') {
             $contents[] = [
                 'type' => 'text',
                 'payload' => $currentText

--- a/Tests/Functional/AfxServiceTest.php
+++ b/Tests/Functional/AfxServiceTest.php
@@ -215,6 +215,24 @@ EOF;
     /**
      * @test
      */
+    public function zeroAndSpaceInAttributesInHtmlTagsAreConvertedToTagAttributes(): void
+    {
+        $afxCode = '<h1 content="0" class=" " />';
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'h1'
+    selfClosingTag = true
+    attributes.content = '0'
+    attributes.class = ' '
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+
+    /**
+     * @test
+     */
     public function sindgleQuotesAreEscapedInAttributesAndChildren(): void
     {
         $afxCode = '<h1 class="foo\'bar" >foo\'bar</h1>';
@@ -297,6 +315,36 @@ EOF;
 Neos.Fusion:Tag {
     tagName = 'h1'
     content = 'Fooo'
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function zeroInContentOfHtmlTagsIsRenderedAsFusionContent(): void
+    {
+        $afxCode = '<h1>0</h1>';
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'h1'
+    content = '0'
+}
+EOF;
+        $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
+    }
+
+    /**
+     * @test
+     */
+    public function spaceInContentOfHtmlTagsIsRenderedAsFusionContent(): void
+    {
+        $afxCode = '<h1> </h1>';
+        $expectedFusion = <<<'EOF'
+Neos.Fusion:Tag {
+    tagName = 'h1'
+    content = ' '
 }
 EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));

--- a/Tests/Functional/ParserTest.php
+++ b/Tests/Functional/ParserTest.php
@@ -65,6 +65,62 @@ class ParserTest extends TestCase
     /**
      * @test
      */
+    public function shouldParseSingleTagWithContent(): void
+    {
+        $parser = new Parser('<div>test</div>');
+
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'node',
+                    'payload' => [
+                        'identifier' => 'div',
+                        'attributes' => [],
+                        'children' => [
+                            0 => [
+                                'type' => 'text',
+                                'payload' => 'test'
+                            ]
+                        ],
+                        'selfClosing' => false
+                    ]
+                ]
+            ],
+            $parser->parse()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldParseSingleTagWithZeroAsContent(): void
+    {
+        $parser = new Parser('<div>0</div>');
+
+        $this->assertEquals(
+            [
+                [
+                    'type' => 'node',
+                    'payload' => [
+                        'identifier' => 'div',
+                        'attributes' => [],
+                        'children' => [
+                            0 => [
+                                'type' => 'text',
+                                'payload' => '0'
+                            ]
+                        ],
+                        'selfClosing' => false
+                    ]
+                ]
+            ],
+            $parser->parse()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function shouldParseSingleSelfClosingTag(): void
     {
         $parser = new Parser('<div/>');


### PR DESCRIPTION
Tags that contained a zero as content (which can occur in for instance in select-options)
were parsed as tag with empty child list because of a weak comparison in the parser code that
treated a zero as falsy.

This change adjusts the comparison and adds tests for zero and space as attributes and contents.