### PR TITLE
TASK: Add php 7.4 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: php
 php:
   - '7.2'
   - '7.3'
+  - '7.4'
 script: composer test

--- a/Classes/Parser/Lexer.php
+++ b/Classes/Parser/Lexer.php
@@ -49,7 +49,7 @@ class Lexer
     public function __construct($string)
     {
         $this->string = $string;
-        $this->currentCharacter = ($string !== '') ? $string{0} : null;
+        $this->currentCharacter = ($string !== '') ? $string[0] : null;
         $this->characterPosition = 0;
     }
 
@@ -250,7 +250,7 @@ class Lexer
      */
     public function rewind(): void
     {
-        $this->currentCharacter = $this->string{--$this->characterPosition};
+        $this->currentCharacter = $this->string[--$this->characterPosition];
     }
 
     /**
@@ -277,7 +277,7 @@ class Lexer
     {
         $c = $this->currentCharacter;
         if ($this->characterPosition < strlen($this->string) - 1) {
-            $this->currentCharacter = $this->string{++$this->characterPosition};
+            $this->currentCharacter = $this->string[++$this->characterPosition];
         } else {
             $this->currentCharacter = null;
         }

--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -216,7 +216,7 @@ class AfxService
             // seperate between attributes (before the first spread), meta attributes
             // spreads and attributes lists between and after spreads
             foreach ($attributes as $attribute) {
-                if ($attribute['type'] === 'prop' && $attribute['payload']['identifier']{0} === '@') {
+                if ($attribute['type'] === 'prop' && $attribute['payload']['identifier'][0] === '@') {
                     $metaAttributes[] = $attribute;
                 } elseif ($attribute['type'] === 'prop' && $spreadIsPresent === false) {
                     $fusionAttributes[] = $attribute;


### PR DESCRIPTION
Aside of the tests the curly brace syntax for accessing single characters in strings is removed in favor of the square brackets as both are identically supported but the curly braces throw warnings since php 7.4